### PR TITLE
feat: add `--analyze-git-history` flag to extract anti-patterns from …

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ uv run autogenerateagentsmd
 
 # Strict Style — Focus purely on strict code constraints, past failures, and repo quirks!
 uv run autogenerateagentsmd --github-repository https://github.com/pallets/flask --style strict
+
+# Analyze Git History — Automatically deduce anti-patterns from recently reverted commits
+uv run autogenerateagentsmd /path/to/local/repo --analyze-git-history
+uv run autogenerateagentsmd --github-repository https://github.com/pallets/flask --style strict --analyze-git-history
 ```
 
 ### 4. Find Your Output

--- a/projects/flask/AGENTS.md
+++ b/projects/flask/AGENTS.md
@@ -1,0 +1,120 @@
+# AGENTS.md — flask
+
+## Code Style & Strict Rules
+
+Code style is strictly enforced by `ruff`, and its rules are non-negotiable.
+
+*   **Linter Rules**: The following `ruff` rule sets are enforced. All code must comply with them.
+    *   `B`: `flake8-bugbear` (Finds potential bugs)
+    *   `E`: `pycodestyle` (Errors)
+    *   `F`: `pyflakes` (Undefined names, unused imports)
+    *   `I`: `isort` (Import sorting)
+    *   `UP`: `pyupgrade` (Modernizes Python syntax)
+    *   `W`: `pycodestyle` (Warnings)
+*   **Import Style**: Imports must be written one per line. Grouping imports on a single line is forbidden.
+    *   **Correct:**
+    ```python
+    from flask import Flask
+    from flask import request
+    ```
+    *   **Incorrect:**
+    ```python
+    from flask import Flask, request
+    ```
+
+## Anti-Patterns & Restrictions
+
+The following patterns are strictly forbidden to maintain code quality, security, and performance.
+
+*   **NEVER use `app.run()` in production.** This is a development-only server. For production, a proper WSGI server like Gunicorn or uWSGI must be used.
+*   **NEVER wrap the `app` object directly for middleware.** To apply middleware, you MUST assign it to the internal WSGI application.
+    *   **Correct:**
+    ```python
+    app.wsgi_app = MyMiddleware(app.wsgi_app)
+    ```
+    *   **Incorrect:**
+    ```python
+    app = MyMiddleware(app)
+    ```
+*   **NEVER use the session for caching or storing large data.** The session is a small, signed cookie intended only for small identifiers (e.g., `user_id`). Storing large objects will severely degrade performance.
+*   **NEVER use context-dependent functions outside of an active request or application context.** Functions like `url_for()` or the `request` object will fail if called at the global scope. If needed, they must be wrapped in an application context.
+    *   **Correct (within a view):**
+    ```python
+    @app.route('/profile')
+    def profile():
+        user_agent = request.headers.get('User-Agent')
+        return f"Your user agent is: {user_agent}"
+    ```
+    *   **Correct (outside a request, e.g., in a script):**
+    ```python
+    with app.app_context():
+        # url_for() can be used here
+        print(url_for('profile'))
+    ```
+    *   **Incorrect (global scope):**
+    ```python
+    # This will raise a RuntimeError
+    profile_url = url_for('profile')
+    ```
+*   **NEVER call internal methods or attributes.** Anything prefixed with an underscore (e.g., `_find_error_handler`) is considered internal and subject to change without notice. Only use the public, documented API.
+
+## Security & Compliance
+
+All contributions must strictly adhere to the following security and compliance rules.
+
+*   **License**: All code must be compatible with the **`BSD-3-Clause`** license.
+*   **NEVER set `debug=True` in production.** This is a critical vulnerability that can expose an interactive debugger and allow remote code execution. The `debug` flag must always be `False` in any production environment.
+*   **NEVER store sensitive data in the user session.** Session data is signed but **not encrypted**, meaning it can be decoded and read by the user. Do not store passwords, secrets, or any Personally Identifiable Information (PII) in the session.
+*   **`secret_key` must be secure**: The application's `secret_key` must be a long, random, and confidential string. A compromised `secret_key` allows attackers to forge sessions.
+*   **Always use `send_from_directory` to serve files.** This function is specifically designed to prevent path traversal attacks. Do not manually construct file paths with user-provided input to serve files.
+
+## Lessons Learned (Past Failures)
+
+The following principles are derived from past experience in maintaining and evolving the framework.
+
+*   **Graceful API Evolution is Crucial**: Instead of making immediate breaking changes, the project uses compatibility wrappers and `DeprecationWarning`. This provides a smoother transition for downstream users and is the required pattern for evolving the public API.
+*   **Proactive Upstream Testing Prevents Breakages**: The `tests-dev` tox environment tests against the `main` branches of core dependencies (Werkzeug, Jinja2, etc.). This practice is essential for detecting and fixing compatibility issues *before* new versions of dependencies are released.
+*   **Separation of Concerns (Sans-IO) Improves Testability**: The core logic is "sans-IO" (agnostic to web protocols) and lives in `src/flask/sansio`. This architectural decision has proven effective for isolating and testing business logic independently from the web layer.
+
+## Repository Quirks & Gotchas
+
+These are non-obvious characteristics of the Flask repository that are essential to understand for effective development.
+
+*   **"Global" Objects are Context-Locals**: The seemingly global objects like `request`, `g`, and `session` are not true globals. They are thread-safe (or task-safe) proxies that point to the object associated with the current, active request. This is a fundamental concept in Flask.
+*   **Middleware is Applied to `app.wsgi_app`**: You do not wrap the Flask `app` object to apply WSGI middleware. Instead, you wrap the internal `app.wsgi_app` attribute.
+*   **Signals are the Preferred Extension Mechanism**: The preferred way to hook into Flask's internal operations (like `request_started` or `app_context_pushed`) is by using Blinker signals. Avoid monkeypatching framework internals.
+*   **`uv` is used for Fast Dependency Management**: The project uses `uv` as a high-performance dependency resolver and `tox` runner (`tox-uv`). Be aware that this is the primary tool for managing environments, not standard `pip`.
+*   **Dual Architecture (Sans-IO vs. WSGI)**: The codebase is split into two distinct parts: the Sans-IO core in `src/flask/sansio` and the WSGI-specific application layer in `src/flask/app`. Understanding which layer you are working in is critical.
+
+## Execution Commands
+
+The agent is permitted to execute the following commands for development, testing, and maintenance.
+
+*   **Run development server:**
+    ```bash
+    flask run
+    ```
+*   **Run the full test suite:**
+    ```bash
+    tox
+    ```
+*   **Run tests for a specific Python environment:**
+    ```bash
+    tox -e py3.12
+    ```
+*   **Check for linting and style issues:**
+    ```bash
+    ruff check .
+    ```
+*   **Automatically fix linting and style issues:**
+    ```bash
+    ruff check --fix .
+    ```
+*   **Format code:**
+    ```bash
+    ruff format .
+    ```
+*   **Build documentation:**
+    ```bash
+    tox -e docs
+    

--- a/src/autogenerateagentsmd/modules.py
+++ b/src/autogenerateagentsmd/modules.py
@@ -8,8 +8,19 @@ from .signatures import (
     ExtractStrictCodebaseInfo,
     CompileStrictConventionsMarkdown,
     ExtractStrictAgentsSections,
+    ExtractLessonsLearnt,
 )
 from .utils import compile_agents_md
+
+class AntiPatternExtractor(dspy.Module):
+    """Extracts lessons learned and anti-patterns from git reversion history."""
+    def __init__(self):
+        super().__init__()
+        self.extract_lessons = dspy.ChainOfThought(ExtractLessonsLearnt)
+
+    def forward(self, git_history: str, repository_name: str) -> dspy.Prediction:
+        logging.info("=> Analyzing git history for repository: %s...", repository_name)
+        return self.extract_lessons(git_history=git_history, repository_name=repository_name)
 
 class CodebaseConventionExtractor(dspy.Module):
     """Extracts raw conventions from codebase source tree using RLM."""

--- a/src/autogenerateagentsmd/signatures.py
+++ b/src/autogenerateagentsmd/signatures.py
@@ -118,3 +118,13 @@ class ExtractStrictAgentsSections(dspy.Signature):
     repo_quirks = dspy.OutputField(desc="Non-obvious gotchas and quirks specific to this project.")
     execution_commands = dspy.OutputField(desc="Commands the agent is allowed to execute.")
 
+class ExtractLessonsLearnt(dspy.Signature):
+    """
+    Analyze the recent git history of reverted commits to deduce explicit anti-patterns,
+    failed experiments, and "lessons learned". This prevents the AI from repeating past mistakes.
+    """
+    git_history: str = dspy.InputField(desc="The commit messages and code diffs of recently reverted changes.")
+    repository_name: str = dspy.InputField(desc="The name of the repository.")
+
+    lessons_learned: str = dspy.OutputField(desc="Lessons Learned: Bullet points explaining what approaches failed in the past and why they were reverted.")
+    anti_patterns_and_restrictions: str = dspy.OutputField(desc="Anti-Patterns: Specific coding practices or architectural choices that this codebase strictly rejects based on the reverted history.")

--- a/tests/test_analyze_git_history.py
+++ b/tests/test_analyze_git_history.py
@@ -1,0 +1,62 @@
+import os
+import subprocess
+import tempfile
+import pytest
+
+from autogenerateagentsmd.utils import extract_reverted_commits
+from autogenerateagentsmd.modules import AntiPatternExtractor
+
+
+def setup_dummy_git_repo(repo_dir: str):
+    """Sets up a dummy git repo with a reverted commit."""
+    # Init git
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_dir, check=True)
+
+    # First commit
+    test_file = os.path.join(repo_dir, "test.py")
+    with open(test_file, "w") as f:
+        f.write("def foo():\n    return 1\n")
+    subprocess.run(["git", "add", "test.py"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=repo_dir, check=True, capture_output=True)
+
+    # Second commit (the one to be reverted)
+    with open(test_file, "w") as f:
+        f.write("def foo():\n    return 'bad pattern'\n")
+    subprocess.run(["git", "add", "test.py"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Add bad pattern"], cwd=repo_dir, check=True, capture_output=True)
+
+    # Revert the second commit
+    subprocess.run(["git", "revert", "--no-edit", "HEAD"], cwd=repo_dir, check=True, capture_output=True)
+
+
+def test_extract_reverted_commits():
+    """Test that extract_reverted_commits correctly finds reverted commits."""
+    with tempfile.TemporaryDirectory() as repo_dir:
+        setup_dummy_git_repo(repo_dir)
+
+        # Extract history
+        git_history = extract_reverted_commits(repo_dir, limit=10)
+        
+        # Verify
+        assert git_history is not None
+        assert "Revert" in git_history or "revert" in git_history.lower()
+        assert "bad pattern" in git_history
+
+
+@pytest.mark.e2e
+def test_anti_pattern_extractor():
+    """Test the AntiPatternExtractor DSPy module natively."""
+    with tempfile.TemporaryDirectory() as repo_dir:
+        setup_dummy_git_repo(repo_dir)
+        git_history = extract_reverted_commits(repo_dir, limit=10)
+
+        extractor = AntiPatternExtractor()
+        result = extractor(git_history=git_history, repository_name="dummy_repo")
+
+        assert result.anti_patterns_and_restrictions is not None
+        assert result.lessons_learned is not None
+        # Just ensure it returned string outputs
+        assert isinstance(result.anti_patterns_and_restrictions, str)
+        assert isinstance(result.lessons_learned, str)


### PR DESCRIPTION
…reverted commits

Added a new pipeline entrypoint that leverages the main LLM to analyze the repository's git history, specifically looking at reverted commits to automatically deduce past failures and codebase-specific anti-patterns. Changes:
- **CLI**: Added `--analyze-git-history` flag to [cli.py](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/cli.py:0:0-0:0) to trigger the analysis path.
- **Git Extraction Utilities**: Created [extract_reverted_commits](cci:1://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/utils.py:82:0-116:17) in [utils.py](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/utils.py:0:0-0:0) to fetch recent `git revert` diffs, complete with a 100,000-character context window safeguard to prevent LLM token overflow.
- **Dedicated DSPy Signatures**: Added [ExtractLessonsLearnt](cci:2://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/signatures.py:120:0-129:199) to [signatures.py](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/signatures.py:0:0-0:0) to focus the LLM explicitly on deducing bad architectural choices from the provided git diffs.
- **Module Orchestration**: Introduced [AntiPatternExtractor](cci:2://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/modules.py:14:0-22:93) into [modules.py](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/modules.py:0:0-0:0) as a standalone `ChainOfThought` process powered by the main (larger) LLM rather than the exploration sub-LLM.
- **Output Compilation**: Integrated the extracted "Lessons Learned" and "Anti-Patterns" directly into the foundational markdown payload, dynamically reflecting past repository mistakes natively in the final [AGENTS.md](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/AGENTS.md:0:0-0:0).
- **Testing**: Added [tests/test_analyze_git_history.py](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/tests/test_analyze_git_history.py:0:0-0:0) to explicitly validate git history extraction and the [AntiPatternExtractor](cci:2://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/modules.py:14:0-22:93) module behavior.
- **Documentation**: Updated the Quick Start examples in `README.md` to demonstrate the usage of the new flag.