### PR TITLE
feat: improve git history analysis with depth control and interactive…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ uv run autogenerateagentsmd --github-repository https://github.com/pallets/flask
 ```
 
 **2. Analyze Git History**
-Automatically deduce anti-patterns from recently reverted commits. This powerful feature uses `git log --grep=revert` to inspect the last 20 reverted commits in the repository. It feeds the diffs into a dedicated DSPy module to extract explicit "Lessons Learned" and "Anti-Patterns", ensuring your AI agent avoids making the exact same mistakes previous human developers made.
+Automatically deduce anti-patterns from recently reverted commits. This powerful feature uses `git log --grep=revert` to inspect reverted commits in the repository (by default, looking back through the last 500 commits). It presents an **interactive prompt** where you can select exactly which reverting commits you want to analyze (e.g. `1,2,3` or `1-5`). It then feeds the diff patches of those selected commits into a dedicated DSPy module to extract explicit "Lessons Learned" and "Anti-Patterns", ensuring your AI agent avoids making the exact same mistakes previous human developers made.
 
 ```bash
-# Works on both local and cloned GitHub repositories
+# Works on both local and cloned GitHub repositories (defaults to scanning 500 commits)
 uv run autogenerateagentsmd /path/to/local/repo --analyze-git-history
-uv run autogenerateagentsmd --github-repository https://github.com/pallets/flask --style strict --analyze-git-history
+
+# Specify a custom limit for how far back to look for reverted commits (e.g., 1000)
+uv run autogenerateagentsmd --github-repository https://github.com/pallets/flask --style strict --analyze-git-history 1000
 ```
 
 ### 4. Find Your Output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-dotenv>=1.0",
     "gepa>=0.0.26",
     "markdown-analysis>=0.1.5",
+    "tqdm>=4.67.3",
 ]
 
 [project.optional-dependencies]

--- a/src/autogenerateagentsmd/cli.py
+++ b/src/autogenerateagentsmd/cli.py
@@ -45,8 +45,10 @@ def parse_arguments():
     )
     parser.add_argument(
         "--analyze-git-history",
-        action="store_true",
-        help="Analyze recent reverted commits to automatically deduce anti-patterns and lessons learned.",
+        nargs="?",
+        const=500,
+        type=int,
+        help="Analyze recent reverted commits to automatically deduce anti-patterns and lessons learned. You can optionally specify the number of commits to fetch (default: 500).",
     )
     add_model_argument(parser)
     return parser.parse_args()
@@ -80,12 +82,12 @@ def resolve_repository_target(args):
 
 
 @contextlib.contextmanager
-def get_repository_context(repo_url=None, local_path=None):
+def get_repository_context(repo_url=None, local_path=None, git_history_limit=None):
     """Provides a context manager that either clones a repo or yields a local path."""
     if repo_url:
         with tempfile.TemporaryDirectory() as temp_repo_dir:
             try:
-                clone_repo(repo_url, temp_repo_dir)
+                clone_repo(repo_url, temp_repo_dir, git_history_limit)
             except Exception as e:
                 raise RuntimeError("Failed to clone repository.") from e
             yield temp_repo_dir
@@ -116,7 +118,7 @@ def setup_language_model(model_arg, api_base=None, api_key=None):
     return lm
 
 
-def run_agents_md_pipeline(repo_dir, repo_name, lm, style="comprehensive", analyze_git_history=False):
+def run_agents_md_pipeline(repo_dir, repo_name, lm, style="comprehensive", analyze_git_history=None):
     """Executes the core pipeline to generate the AGENTS.md document."""
     # Load source tree
     logging.info(f"Loading source tree from {repo_dir}...")
@@ -126,8 +128,8 @@ def run_agents_md_pipeline(repo_dir, repo_name, lm, style="comprehensive", analy
 
     git_anti_patterns = ""
     git_lessons = ""
-    if analyze_git_history:
-        git_history = extract_reverted_commits(repo_dir)
+    if analyze_git_history is not None:
+        git_history = extract_reverted_commits(repo_dir, limit=analyze_git_history)
         if git_history:
             logging.info("\n[0/3] Extracting lessons learned from git history using main LLM...")
             anti_pattern_extractor = AntiPatternExtractor()
@@ -138,7 +140,8 @@ def run_agents_md_pipeline(repo_dir, repo_name, lm, style="comprehensive", analy
             logging.info(f"Lessons Learned:\n{git_lessons}")
             logging.info(f"Anti-Patterns:\n{git_anti_patterns}")
         else:
-            logging.info("No reverted git history found to analyze.")
+            logging.info("No reverted git history found or selected. Exiting early as requested.")
+            sys.exit(0)
 
     # Step 1: Extract Conventions
     logging.info(f"\n[1/3] Scanning codebase tree for '{repo_name}' using RLM (style: {style})...")
@@ -147,7 +150,7 @@ def run_agents_md_pipeline(repo_dir, repo_name, lm, style="comprehensive", analy
     
     conventions_md = conventions_result.markdown_document
     # Append git insights to the conventions markdown so it flows into AGENTS.md
-    if analyze_git_history and (git_anti_patterns or git_lessons):
+    if analyze_git_history is not None and (git_anti_patterns or git_lessons):
         conventions_md += f"\n\n## Git History Insights\n\n### Lessons Learned\n{git_lessons}\n\n### Anti-Patterns\n{git_anti_patterns}\n"
 
     logging.info("\n--- Extracted Conventions Document ---")
@@ -179,7 +182,7 @@ def main():
         repo_url, local_path, repo_name = resolve_repository_target(args)
         lm = setup_language_model(args.model, api_base=getattr(args, 'api_base', None), api_key=getattr(args, 'api_key', None))
 
-        with get_repository_context(repo_url=repo_url, local_path=local_path) as repo_dir:
+        with get_repository_context(repo_url=repo_url, local_path=local_path, git_history_limit=args.analyze_git_history) as repo_dir:
             run_agents_md_pipeline(repo_dir, repo_name, lm, style=args.style, analyze_git_history=args.analyze_git_history)
 
     except (FileNotFoundError, RuntimeError) as e:

--- a/src/autogenerateagentsmd/utils.py
+++ b/src/autogenerateagentsmd/utils.py
@@ -68,11 +68,12 @@ def load_source_tree(root_dir: str) -> dict[str, TreeType]:
                 
     return tree
 
-def clone_repo(repo_url: str, dest_dir: str):
+def clone_repo(repo_url: str, dest_dir: str, depth: int = None):
     """Clone a public GitHub repo to a destination directory."""
     logging.info(f"Cloning {repo_url} into {dest_dir}...")
     try:
-        subprocess.run(["git", "clone", "--depth", "1", repo_url, dest_dir], check=True, capture_output=True, text=True)
+        depth_param = str(max(depth, 1)) if depth is not None else "1"
+        subprocess.run(["git", "clone", "--depth", depth_param, repo_url, dest_dir], check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as e:
         logging.error(f"Failed to clone repository: {e.stderr}")
         raise
@@ -80,21 +81,103 @@ def clone_repo(repo_url: str, dest_dir: str):
         logging.error("Git is not installed or not found in system path.")
         raise
 
-def extract_reverted_commits(repo_dir: str, limit: int = 20) -> str:
-    """Extracts git history for reverting commits to deduce past failures."""
-    logging.info(f"Analyzing git history for reverted commits (limit: {limit})...")
+def parse_selection(selection: str, max_val: int) -> list[int]:
+    selection = selection.lower().strip()
+    if selection == "all":
+        return list(range(1, max_val + 1))
+    
+    sel = set()
+    for part in re.split(r",|\s+", selection):
+        part = part.strip()
+        if not part:
+            continue
+        if ".." in part:
+            start_str, end_str = part.split("..", 1)
+        elif "-" in part:
+            start_str, end_str = part.split("-", 1)
+        else:
+            try:
+                sel.add(int(part))
+            except ValueError:
+                pass
+            continue
+        try:
+            start, end = int(start_str), int(end_str)
+            if start <= end:
+                sel.update(range(start, end + 1))
+        except ValueError:
+            pass
+    return sorted([i for i in sel if 1 <= i <= max_val])
+
+def extract_reverted_commits(repo_dir: str, limit: int = 500) -> str:
+    """Extracts git history for reverting commits interactively."""
+    logging.info(f"Finding recent reverted commits (limit: {limit})...")
     try:
-        # Run git log fetching the diffs of commits mentioning 'revert'
+        # Run git log fetching just the hashes and subjects
         result = subprocess.run(
-            ["git", "log", f"-n {limit}", "--grep=revert", "-i", "--patch"],
+            ["git", "log", f"-n {limit}", "--grep=revert", "-i", "--format=%H %s"],
             cwd=repo_dir,
             check=True,
             capture_output=True,
             text=True
         )
         
-        diff_text = result.stdout
+        lines = [line.strip() for line in result.stdout.split('\n') if line.strip()]
         
+        if not lines:
+            logging.info("No reverted commits found in recent history.")
+            return ""
+
+        print("\n--- Found the following revert commits ---")
+        commits = []
+        for i, line in enumerate(lines, 1):
+            hash_val, subject = line.split(" ", 1)
+            commits.append(hash_val)
+            print(f"[{i}] {hash_val[:7]} - {subject}")
+
+        print("\nSelect the commits you want to analyze.")
+        print("Options: 'all', '1,2,3', '1-5', '1..5', etc.")
+        
+        try:
+            selection_input = input("Enter selection [all]: ").strip()
+        except Exception:
+            selection_input = "all"
+            
+        if not selection_input:
+            selection_input = "all"
+
+        selected_indices = parse_selection(selection_input, len(commits))
+        
+        if not selected_indices:
+            logging.info("No valid commits selected. Skipping git history analysis.")
+            return ""
+
+        selected_hashes = [commits[i - 1] for i in selected_indices]
+        
+        # Try to import tqdm for progress bar
+        try:
+            from tqdm import tqdm
+            iterable = tqdm(selected_hashes, desc="Fetching commit diffs")
+        except ImportError:
+            iterable = selected_hashes
+            logging.info(f"Fetching diffs for {len(selected_hashes)} commits...")
+
+        diffs = []
+        for hash_val in iterable:
+            try:
+                patch_result = subprocess.run(
+                    ["git", "show", "--patch", hash_val],
+                    cwd=repo_dir,
+                    check=True,
+                    capture_output=True,
+                    text=True
+                )
+                diffs.append(patch_result.stdout)
+            except subprocess.CalledProcessError as e:
+                logging.warning(f"Failed to fetch patch for {hash_val}: {e.stderr}")
+
+        diff_text = "\n".join(diffs)
+
         # Check context length safely
         if len(diff_text) > 100000:
             logging.warning(
@@ -102,10 +185,6 @@ def extract_reverted_commits(repo_dir: str, limit: int = 20) -> str:
                 "Truncating to 100,000 characters to prevent context window overflow."
             )
             diff_text = diff_text[:100000] + "\n... [TRUNCATED DUE TO LENGTH]"
-            
-        if not diff_text.strip():
-            logging.info("No reverted commits found in recent history.")
-            return ""
             
         return diff_text
         

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def test_parse_arguments_defaults():
         assert args.local_repo_pos == '/tmp/repo'
         assert args.github_repository is None
         assert args.style == 'comprehensive'
-        assert args.analyze_git_history is False
+        assert args.analyze_git_history is None
         assert args.model is None
         assert args.api_base is None
         assert args.api_key is None
@@ -37,7 +37,7 @@ def test_parse_arguments_flags():
         args = parse_arguments()
         assert args.github_repository == 'https://github.com/foo/bar'
         assert args.style == 'strict'
-        assert args.analyze_git_history is True
+        assert args.analyze_git_history == 500
         assert args.model == 'openai'
         assert args.api_base == 'http://localhost:11434'
         assert args.api_key == 'secret-key'

--- a/uv.lock
+++ b/uv.lock
@@ -185,6 +185,7 @@ dependencies = [
     { name = "litellm" },
     { name = "markdown-analysis" },
     { name = "python-dotenv" },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
@@ -202,6 +203,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "tqdm", specifier = ">=4.67.3" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
… selection - - Changed  from a boolean flag to accept an optional integer argument (defaulting to ), representing the number of recent commits to scan for reverts.

- Modified [clone_repo](cci:1://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/utils.py:70:0-81:13) to dynamically set the  based on the specified git history limit, fixing an issue where previous shallow cloning () prevented analysis of older commits.
- Added interactive selection flow in [extract_reverted_commits](cci:1://file:///Users/ank/Documents/AutogenerateAgentsMD.md/src/autogenerateagentsmd/utils.py:111:0-195:17). It now first lists the found reverted commits and prompts the user to select which ones to analyze (supports syntaxes like all, 1,2,3, 1-5, 1..5).
- Integrated  to display a progress bar while the diff patches for the selected commits are being fetched.
- Updated [cli.py](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/tests/test_cli.py:0:0-0:0) to gracefully explicitly exit the application if  is requested but no reverted commits are found or the user selects none.
- Updated [cli.py](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/tests/test_cli.py:0:0-0:0) argument parsing logic and updated corresponding unit tests in [test_cli.py](cci:7://file:///Users/ank/Documents/AutogenerateAgentsMD.md/tests/test_cli.py:0:0-0:0) to match the new  /  default behavior.
- Added  to project dependencies.